### PR TITLE
Better logging

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -1,6 +1,10 @@
 package engine
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/hybridgroup/mechanoid"
+)
 
 var (
 	ErrInvalidEngine     = errors.New("engine: invalid engine")
@@ -40,19 +44,19 @@ func (e *Engine) Init() error {
 		return ErrNoInterpreter
 	}
 
-	println("Initializing interpreter...")
+	mechanoid.Log("Initializing interpreter...")
 	if err := e.Interpreter.Init(); err != nil {
 		return err
 	}
 
 	if e.FileStore != nil {
-		println("Initializing file store...")
+		mechanoid.Log("Initializing file store...")
 		if err := e.FileStore.Init(); err != nil {
 			return err
 		}
 	}
 
-	println("Initializing devices...")
+	mechanoid.Log("Initializing devices...")
 	for _, d := range e.Devices {
 		if err := d.Init(); err != nil {
 			return err

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -50,9 +50,6 @@ func (i *mockInterpreter) DefineFunc(modulename, funcname string, f interface{})
 	return nil
 }
 
-func (i *mockInterpreter) Log(msg string) {
-}
-
 func (i *mockInterpreter) MemoryData(ptr, sz uint32) ([]byte, error) {
 	return nil, nil
 }

--- a/engine/interp.go
+++ b/engine/interp.go
@@ -13,8 +13,6 @@ type Interpreter interface {
 	Halt() error
 	// DefineFunc defines a function in the host module.
 	DefineFunc(module, name string, f interface{}) error
-	// Log logs a message.
-	Log(msg string)
 	// MemoryData returns a slice of memory data from the memory managed by the host.
 	MemoryData(ptr, sz uint32) ([]byte, error)
 }

--- a/filestore/flash/flash.go
+++ b/filestore/flash/flash.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 
+	"github.com/hybridgroup/mechanoid"
 	"github.com/hybridgroup/mechanoid/engine"
 	"tinygo.org/x/tinyfs"
 	"tinygo.org/x/tinyfs/littlefs"
@@ -57,15 +58,15 @@ func (fs *FileStore) Init() error {
 	fs.lfs = lfs
 
 	// Mount the filesystem
-	println("Mounting filesystem...")
+	mechanoid.Log("Mounting filesystem...")
 	if err := fs.lfs.Mount(); err != nil {
 		// if the filesystem cannot be mounted, try to format it
-		println("Formatting new filesystem...")
+		mechanoid.Log("Formatting new filesystem...")
 		if err := fs.lfs.Format(); err != nil {
 			return err
 		}
 
-		println("Mounting new filesystem...")
+		mechanoid.Log("Mounting new filesystem...")
 		// if the format was successful, try to mount again
 		if err := fs.lfs.Mount(); err != nil {
 			return err

--- a/interp/wasman/interp.go
+++ b/interp/wasman/interp.go
@@ -1,6 +1,7 @@
 package wasman
 
 import (
+	"github.com/hybridgroup/mechanoid"
 	"github.com/hybridgroup/mechanoid/engine"
 
 	wasmaneng "github.com/hybridgroup/wasman"
@@ -39,7 +40,7 @@ func (i *Interpreter) Init() error {
 func (i *Interpreter) Load(code []byte) error {
 	conf := config.ModuleConfig{
 		Recover: true,
-		Logger:  i.Log,
+		Logger:  mechanoid.Log,
 	}
 
 	var err error
@@ -135,10 +136,6 @@ func (i *Interpreter) DefineFunc(moduleName, funcName string, f interface{}) err
 	default:
 		return engine.ErrInvalidFuncType
 	}
-}
-
-func (i *Interpreter) Log(msg string) {
-	println(msg)
 }
 
 func (i *Interpreter) MemoryData(ptr, sz uint32) ([]byte, error) {

--- a/log.go
+++ b/log.go
@@ -1,0 +1,8 @@
+package mechanoid
+
+// Log a message into terminal if debug mode is enabled
+func Log(msg string) {
+	if debug {
+		println(msg)
+	}
+}


### PR DESCRIPTION
Replace debug `println` calls with `mechanoid.Log` which prints messages only if debug mode is enabled. 