### PR TITLE
cmd/mecha: correct issue with 'new module' command when missing dependencies

### DIFF
--- a/cmd/mecha/create.go
+++ b/cmd/mecha/create.go
@@ -90,11 +90,11 @@ func createFromTemplate(templ, proj string) error {
 
 func getModuleName() (string, error) {
 	var stdout, stderr bytes.Buffer
-	cmd := exec.Command("go", "list", "-f", "{{.ImportPath}}")
+	cmd := exec.Command("go", "list", "-e", "-f", "{{.ImportPath}}")
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		fmt.Printf("go list -f {{.ImportPath}}: %v\n%s%s", err, stderr.Bytes(), stdout.Bytes())
+		fmt.Printf("go list -e -f {{.ImportPath}}: %v\n%s%s", err, stderr.Bytes(), stdout.Bytes())
 		os.Exit(1)
 
 	}


### PR DESCRIPTION
This PR modifies the `mecha` command to correct an issue with 'new module' command when missing project dependencies.

The 'go list' command needs the '-e' flag to ignore errors, such as missing files from //go:embed directives.

Fixes #12 