### PR TITLE
interp/wasman: add host memory connection for Store that is compatibl…

### DIFF
--- a/interp/wasman/interp.go
+++ b/interp/wasman/interp.go
@@ -145,9 +145,8 @@ func (i *Interpreter) defineModule(modName string, m wypes.Module, refs wypes.Re
 func (i *Interpreter) adaptHostFunc(hf wypes.HostFunc, refs wypes.Refs) wasm.RawHostFunc {
 	return func(stack []uint64) []uint64 {
 		adaptedStack := wypes.SliceStack(stack)
-		// TODO(@orsinium): adapt and pass the actual memory
 		store := wypes.Store{
-			Memory:  nil,
+			Memory:  &memoryReaderWriter{data: i.Memory},
 			Stack:   &adaptedStack,
 			Refs:    refs,
 			Context: nil,
@@ -179,4 +178,23 @@ func wrapValueTypes(ins []wypes.ValueType) []types.ValueType {
 		outs = append(outs, types.ValueType(in))
 	}
 	return outs
+}
+
+type memoryReaderWriter struct {
+	data []byte
+}
+
+func (m *memoryReaderWriter) Read(offset, count uint32) ([]byte, bool) {
+	if offset+count > uint32(len(m.data)) {
+		return nil, false
+	}
+	return m.data[offset : offset+count], true
+}
+
+func (m *memoryReaderWriter) Write(offset uint32, v []byte) bool {
+	if offset+uint32(len(v)) > uint32(len(m.data)) {
+		return false
+	}
+	copy(m.data[offset:], v)
+	return true
 }


### PR DESCRIPTION
This PR adds a host memory connection to wasman for `Store` that is compatible with the wazero `api.Memory` interface.