### PR TITLE
log: correctly separate normal Log() from Debug() logging

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -2,4 +2,4 @@
 
 package mechanoid
 
-var Debug = true
+var Debugging = true

--- a/interp/wasman/interp.go
+++ b/interp/wasman/interp.go
@@ -48,9 +48,9 @@ func (i *Interpreter) Init() error {
 func (i *Interpreter) Load(code engine.Reader) error {
 	ms := runtime.MemStats{}
 
-	if mechanoid.Debug {
+	if mechanoid.Debugging {
 		runtime.ReadMemStats(&ms)
-		println("Interpreter Load - Heap Used: ", ms.HeapInuse, " Free: ", ms.HeapIdle, " Meta: ", ms.GCSys)
+		mechanoid.Debug("Interpreter Load - Heap Used: ", ms.HeapInuse, " Free: ", ms.HeapIdle, " Meta: ", ms.GCSys)
 	}
 
 	conf := config.ModuleConfig{
@@ -70,9 +70,9 @@ func (i *Interpreter) Load(code engine.Reader) error {
 func (i *Interpreter) Run() (engine.Instance, error) {
 	ms := runtime.MemStats{}
 
-	if mechanoid.Debug {
+	if mechanoid.Debugging {
 		runtime.ReadMemStats(&ms)
-		println("Interpreter Run - Heap Used: ", ms.HeapInuse, " Free: ", ms.HeapIdle, " Meta: ", ms.GCSys)
+		mechanoid.Debug("Interpreter Run - Heap Used: ", ms.HeapInuse, " Free: ", ms.HeapIdle, " Meta: ", ms.GCSys)
 	}
 
 	var err error
@@ -95,9 +95,9 @@ func (i *Interpreter) Run() (engine.Instance, error) {
 func (i *Interpreter) Halt() error {
 	ms := runtime.MemStats{}
 
-	if mechanoid.Debug {
+	if mechanoid.Debugging {
 		runtime.ReadMemStats(&ms)
-		println("Interpreter Halt - Heap Used: ", ms.HeapInuse, " Free: ", ms.HeapIdle, " Meta: ", ms.GCSys)
+		mechanoid.Debug("Interpreter Halt - Heap Used: ", ms.HeapInuse, " Free: ", ms.HeapIdle, " Meta: ", ms.GCSys)
 	}
 
 	// clean up extern refs
@@ -108,9 +108,9 @@ func (i *Interpreter) Halt() error {
 	// force a garbage collection to free memory
 	runtime.GC()
 
-	if mechanoid.Debug {
+	if mechanoid.Debugging {
 		runtime.ReadMemStats(&ms)
-		println("Interpreter Halt after GC - Heap Used: ", ms.HeapInuse, " Free: ", ms.HeapIdle, " Meta: ", ms.GCSys)
+		mechanoid.Debug("Interpreter Halt after GC - Heap Used: ", ms.HeapInuse, " Free: ", ms.HeapIdle, " Meta: ", ms.GCSys)
 	}
 
 	return nil

--- a/log.go
+++ b/log.go
@@ -1,8 +1,13 @@
 package mechanoid
 
-// Log a message into terminal if debug mode is enabled
+// Log a message into terminal.
 func Log(msg string) {
-	if Debug {
-		println(msg)
+	println(msg)
+}
+
+// Log a message into terminal if debug mode is enabled
+func Debug(args ...any) {
+	if Debugging {
+		println(args)
 	}
 }

--- a/nodebug.go
+++ b/nodebug.go
@@ -2,4 +2,4 @@
 
 package mechanoid
 
-var Debug = false
+var Debugging = false


### PR DESCRIPTION
This PR improves logging by correctly separating normal `mechanoid.Log()` which you would expect to always appear from 
 a new `mechanoid.Debug()` function for logging only when `-tags=debug`.