### PR TITLE
Define wazero modules directly

### DIFF
--- a/interp/wazero/interp.go
+++ b/interp/wazero/interp.go
@@ -41,7 +41,8 @@ func (i *Interpreter) SetModules(modules wypes.Modules) error {
 	for modName, funcs := range modules {
 		_, found := i.modules[modName]
 		if !found {
-			i.modules[modName] = wypes.Module{}
+			i.modules[modName] = funcs
+			continue
 		}
 		for funcName, funcDef := range funcs {
 			i.modules[modName][funcName] = funcDef


### PR DESCRIPTION
Do not trust to wypes to define wazero modules. Do all the same but on the mechanoid side. It gives us more control over which version of wazero is used and gives more control.

Also do fewer allocations in SetModules