### PR TITLE
Update wypes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ replace github.com/tetratelabs/wazero => github.com/orsinium-forks/wazero v0.0.0
 
 require (
 	github.com/hybridgroup/wasman v0.0.0-20240304140329-ce1ea6b61834
-	github.com/orsinium-labs/wypes v0.1.1
+	github.com/orsinium-labs/wypes v0.1.2
 	github.com/tetratelabs/wazero v1.6.0
 	github.com/urfave/cli/v2 v2.27.1
 	tinygo.org/x/tinyfs v0.3.1-0.20231212053859-32ae3f6bbad9

--- a/go.sum
+++ b/go.sum
@@ -6,10 +6,8 @@ github.com/orsinium-forks/wazero v0.0.0-20240217173836-b12c024bcbe4 h1:MUh9e2izc
 github.com/orsinium-forks/wazero v0.0.0-20240217173836-b12c024bcbe4/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
 github.com/orsinium-labs/tinytest v1.0.0 h1:YiGm/whlGm3mn/ynx9CCFuvEa3Q6yEGrzrKXEqJOkdc=
 github.com/orsinium-labs/tinytest v1.0.0/go.mod h1:GwcYBp0aKi6zujzBXFpCnqw6RSLSp9JSedDyu/V1DF4=
-github.com/orsinium-labs/wypes v0.1.0 h1:WSw47er3Dz2nHzw1D20mt57W2i+Rm0sI6c4uSm1XdKM=
-github.com/orsinium-labs/wypes v0.1.0/go.mod h1:FSNWGo8I6/D5RYXMkCxyu71TXJAlwJGQUxgs4i6MAwo=
-github.com/orsinium-labs/wypes v0.1.1 h1:i8J8wDnoJERQoK5JXQomlAYER8MyySgZQPE8hRDvRiM=
-github.com/orsinium-labs/wypes v0.1.1/go.mod h1:FSNWGo8I6/D5RYXMkCxyu71TXJAlwJGQUxgs4i6MAwo=
+github.com/orsinium-labs/wypes v0.1.2 h1:xa+d83u6jkGENM2I63KY1dxTC9S/D2At/rB7EsvU5QY=
+github.com/orsinium-labs/wypes v0.1.2/go.mod h1:FSNWGo8I6/D5RYXMkCxyu71TXJAlwJGQUxgs4i6MAwo=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/urfave/cli/v2 v2.27.1 h1:8xSQ6szndafKVRmfyeUMxkNUJQMjL1F2zmsZ+qHpfho=

--- a/interp/wasman/interp.go
+++ b/interp/wasman/interp.go
@@ -145,8 +145,9 @@ func (i *Interpreter) defineModule(modName string, m wypes.Module, refs wypes.Re
 func (i *Interpreter) adaptHostFunc(hf wypes.HostFunc, refs wypes.Refs) wasm.RawHostFunc {
 	return func(stack []uint64) []uint64 {
 		adaptedStack := wypes.SliceStack(stack)
+		adaptedMemory := wypes.SliceMemory(i.Memory)
 		store := wypes.Store{
-			Memory:  &memoryReaderWriter{data: i.Memory},
+			Memory:  &adaptedMemory,
 			Stack:   &adaptedStack,
 			Refs:    refs,
 			Context: nil,
@@ -178,23 +179,4 @@ func wrapValueTypes(ins []wypes.ValueType) []types.ValueType {
 		outs = append(outs, types.ValueType(in))
 	}
 	return outs
-}
-
-type memoryReaderWriter struct {
-	data []byte
-}
-
-func (m *memoryReaderWriter) Read(offset, count uint32) ([]byte, bool) {
-	if offset+count > uint32(len(m.data)) {
-		return nil, false
-	}
-	return m.data[offset : offset+count], true
-}
-
-func (m *memoryReaderWriter) Write(offset uint32, v []byte) bool {
-	if offset+uint32(len(v)) > uint32(len(m.data)) {
-		return false
-	}
-	copy(m.data[offset:], v)
-	return true
 }


### PR DESCRIPTION
1. Includes a fix for string reading from memory: https://github.com/orsinium-labs/wypes/pull/2
2. Includes out-of-the-box slice to memory adapter that we can use for wasman.