### PR TITLE
all: updates to the latest versions of dependent packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,6 @@ func pong()
 func ping() {
  pong()
 }
-
-func main() {}
 ```
 
 You can compile this program to WASM using the `mecha build` command:
@@ -205,8 +203,8 @@ See [ARCHITECTURE.md](./ARCHITECTURE.md) for more information.
 
 ## Supported Runtime Interpreters
 
-- [wazero](https://github.com/tetratelabs/wazero)
-- [wasman](https://github.com/hybridgroup/wasman) - requires the https://github.com/hybridgroup/wasman fork
+- [wasman](https://github.com/hybridgroup/wasman)
+- [wazero](https://github.com/tetratelabs/wazero) - at the moment, not functional due to upstream changes.
 
 ## Goals
 

--- a/cmd/mecha/main.go
+++ b/cmd/mecha/main.go
@@ -14,7 +14,7 @@ var (
 	}
 
 	buildFlags = []cli.Flag{
-		&cli.StringFlag{Name: "interpreter", Aliases: []string{"i"}, Value: "wazero", Usage: "WebAssembly interpreter to use (wasman, wazero)"},
+		&cli.StringFlag{Name: "interpreter", Aliases: []string{"i"}, Value: "wasman", Usage: "WebAssembly interpreter to use (wasman, wazero)"},
 		&cli.BoolFlag{Name: "debug", Aliases: []string{"d"}, Usage: "perform additional logging for debugging"},
 		&cli.StringSliceFlag{
 			Name:  "params",

--- a/cmd/mecha/version.go
+++ b/cmd/mecha/version.go
@@ -1,7 +1,7 @@
 package main
 
 var (
-	version = "0.2.0"
+	version = "0.3.0-dev"
 	sha     string
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,12 @@
 module github.com/hybridgroup/mechanoid
 
-go 1.22.0
+go 1.22.1
+
+toolchain go1.24.1
 
 require (
 	github.com/hybridgroup/wasman v0.0.0-20240304140329-ce1ea6b61834
-	github.com/orsinium-labs/wypes v0.1.4
-	github.com/tetratelabs/wazero v1.7.1-0.20240331091131-22e386151092
-	tinygo.org/x/tinyfs v0.3.1-0.20231212053859-32ae3f6bbad9
+	github.com/orsinium-labs/wypes v0.3.2
+	github.com/tetratelabs/wazero v1.9.0
+	tinygo.org/x/tinyfs v0.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,9 +2,9 @@ github.com/hybridgroup/wasman v0.0.0-20240304140329-ce1ea6b61834 h1:pP916/7OLrom
 github.com/hybridgroup/wasman v0.0.0-20240304140329-ce1ea6b61834/go.mod h1:rLavUo4P0xVcDeDnViYEpPQPoACmp1py9UTLPY/R7Lg=
 github.com/orsinium-labs/tinytest v1.0.0 h1:YiGm/whlGm3mn/ynx9CCFuvEa3Q6yEGrzrKXEqJOkdc=
 github.com/orsinium-labs/tinytest v1.0.0/go.mod h1:GwcYBp0aKi6zujzBXFpCnqw6RSLSp9JSedDyu/V1DF4=
-github.com/orsinium-labs/wypes v0.1.4 h1:+7oih2IDlEpz7laiL3sQFlIU8vjd5j/SwcYlPdIPc0Q=
-github.com/orsinium-labs/wypes v0.1.4/go.mod h1:FSNWGo8I6/D5RYXMkCxyu71TXJAlwJGQUxgs4i6MAwo=
-github.com/tetratelabs/wazero v1.7.1-0.20240331091131-22e386151092 h1:Yfu1ffUxZBN07aD9qvVZmZEakyNQAal6vWBF0cB/UUU=
-github.com/tetratelabs/wazero v1.7.1-0.20240331091131-22e386151092/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
-tinygo.org/x/tinyfs v0.3.1-0.20231212053859-32ae3f6bbad9 h1:u3w9x/Jo4A5Q+WxABVd15dD2ScTI7B6DmGb3lTKNP/w=
-tinygo.org/x/tinyfs v0.3.1-0.20231212053859-32ae3f6bbad9/go.mod h1:smxJYYJRbfvbQofdYoECIBPHQZJTKd4YeS3ZLvx+lpQ=
+github.com/orsinium-labs/wypes v0.3.2 h1:CwCxfjjPxdLivPk7pg4d1yOnc9tnjeWcZvyYxG35d5M=
+github.com/orsinium-labs/wypes v0.3.2/go.mod h1:FSNWGo8I6/D5RYXMkCxyu71TXJAlwJGQUxgs4i6MAwo=
+github.com/tetratelabs/wazero v1.9.0 h1:IcZ56OuxrtaEz8UYNRHBrUa9bYeX9oVY93KspZZBf/I=
+github.com/tetratelabs/wazero v1.9.0/go.mod h1:TSbcXCfFP0L2FGkRPxHphadXPjo1T6W+CseNNY7EkjM=
+tinygo.org/x/tinyfs v0.5.0 h1:1nLSvtvvoNcK3Ii+Dib9MVe4y/Fnp2iMgzbKgADGfbs=
+tinygo.org/x/tinyfs v0.5.0/go.mod h1:45hZCJ5e4rJxc3BaJTy1qhe5N+LbF/CpuFS4jPhhYuo=

--- a/interp/wasman/interp.go
+++ b/interp/wasman/interp.go
@@ -122,7 +122,7 @@ func (i *Interpreter) adaptHostFunc(hf wypes.HostFunc, refs wypes.Refs) wasm.Raw
 			Refs:    refs,
 			Context: nil,
 		}
-		hf.Call(store)
+		hf.Call(&store)
 		return stack
 	}
 }

--- a/interp/wazero/interp.go
+++ b/interp/wazero/interp.go
@@ -128,7 +128,7 @@ func wazeroAdaptHostFunc(hf wypes.HostFunc, refs wypes.Refs) api.GoModuleFunctio
 			Refs:    refs,
 			Context: ctx,
 		}
-		hf.Call(store)
+		hf.Call(&store)
 	})
 }
 

--- a/version.go
+++ b/version.go
@@ -1,7 +1,7 @@
 package mechanoid
 
 var (
-	version = "0.2.0"
+	version = "0.3.0-dev"
 	sha     string
 )
 


### PR DESCRIPTION
This PR updates to the latest versions of dependent packages, however due to upstream changes the `wazero` runtime is not able to be compiled with TinyGo. The default runtime is now set to `wasman` as a result.