### PR TITLE
fix: copy zig binaries from new output location after build

### DIFF
--- a/cmd/mecha/build.go
+++ b/cmd/mecha/build.go
@@ -208,7 +208,7 @@ func buildZigModule(modulesPath, name string) error {
 		os.Exit(1)
 	}
 
-	if err := copyFile(filepath.Join(modulePath, "zig-out", "lib", name+".wasm"), filepath.Join(modulesPath, name+".wasm")); err != nil {
+	if err := copyFile(filepath.Join(modulePath, "zig-out", "bin", name+".wasm"), filepath.Join(modulesPath, name+".wasm")); err != nil {
 		fmt.Printf("copy file error %s: %v\n", modulePath, err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
This PR is to handle that the output location for zig binaries has changed, so we need to copy files from new place after building modules.